### PR TITLE
Fix inconsistent notation with Fisher score

### DIFF
--- a/_posts/2020-04-11-fisher.md
+++ b/_posts/2020-04-11-fisher.md
@@ -46,7 +46,7 @@ Now here comes the definition of Fisher's score function, which really is nothin
 
 
 $$
-u(\theta) = \nabla_\theta \log p(x \vert \theta)
+s(\theta) = \nabla_\theta \log p(x \vert \theta)
 $$
 
 


### PR DESCRIPTION
Thanks a lot for sharing! Very nice writeup.

I think you switched notation from the definition $u(\theta)$ to $s(\theta)$ without updating the definition itself?

Public link: https://jaketae.github.io/study/fisher/